### PR TITLE
fix(strm-2276): add missing agent rbac & fix default postgres pw setup

### DIFF
--- a/helm/templates/batch-exporters-agent/rbac.yaml
+++ b/helm/templates/batch-exporters-agent/rbac.yaml
@@ -32,6 +32,16 @@ rules:
       - patch
       - get
       - delete
+  - apiGroups:
+      - ""
+      - apps
+    resources:
+      - replicasets
+      - pods
+      - pods/log
+    verbs:
+      - list
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/templates/batch-job-agent/deployment.yaml
+++ b/helm/templates/batch-job-agent/deployment.yaml
@@ -44,9 +44,9 @@ spec:
             - name: STRM_DATABASE_USERNAME
               value: {{$config.postgres.user | default "postgres" }}
             - name: STRM_DATABASE_CREDENTIALS_PASSWORD_KUBERNETES_SECRET_NAME
-              value: {{ $postgres.fullnameOverride }}
+              value: {{$config.postgres.passwordSecretName | default "postgres" }}
             - name: STRM_DATABASE_CREDENTIALS_PASSWORD_KUBERNETES_SECRET_KEY_NAME
-              value: "{{ $postgres.fullnameOverride }}-password"
+              value: "{{$config.postgres.passwordSecretKeyName | default "postgres-password" }}"
             - name: STRM_DATABASE_CONNECTION_HOST
               value: "{{$postgresHost}}"
 

--- a/helm/templates/batch-job-agent/postgres-secret.yaml
+++ b/helm/templates/batch-job-agent/postgres-secret.yaml
@@ -1,6 +1,6 @@
 {{ $component := .Values.components.batchJobAgent }}
-{{ if and $component.enabled (not .Values.postgresql.enabled) }}
-# create a secret with the password from the value in the batchJobAgent section
+{{ if and $component.enabled (not .Values.postgresql.enabled) $component.configuration.postgres.password }}
+# Create a secret with the postgres password, but only when using a custom postgres DB and if a password was provided (otherwise a custom secret must already exist)
 
 apiVersion: v1
 data:

--- a/helm/templates/streams-agent/rbac.yaml
+++ b/helm/templates/streams-agent/rbac.yaml
@@ -31,6 +31,16 @@ rules:
       - patch
       - get
       - delete
+  - apiGroups:
+      - ""
+      - apps
+    resources:
+      - replicasets
+      - pods
+      - pods/log
+    verbs:
+      - list
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -494,9 +494,7 @@
                 "postgres": {
                   "type": "object",
                   "default": {},
-                  "required": [
-                    "password"
-                  ],
+                  "required": [],
                   "properties": {
                     "host": {
                       "type": [
@@ -520,10 +518,27 @@
                       "default": null
                     },
                     "password": {
-                      "type": "string",
-                      "default": ""
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "default": null
                     },
                     "database": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "default": null
+                    },
+                    "passwordSecretName": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "default": null
+                    },
+                    "passwordSecretKeyName": {
                       "type": [
                         "string",
                         "null"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,8 +50,10 @@ postgresql:
   enabled: true
   fullnameOverride: "postgres"
   auth:
-    # The postgres user's password doesn't get set correctly due to an issue with the bitnami chart, so we create a different user here
-    # See https://github.com/bitnami/charts/issues/14469
+    # For dev purposes, using the default 'postgres' user is unpractical, since the password changes after uninstalls /
+    # fresh installs, mismatching with the Persistent Volume Claims (which are not deleted by default upon uninstall).
+    # Therefore we create a different user with static password. (Again, the built-in postgres/redis/kafka are not meant
+    # for production usage!)
     username: batch-jobs-user
     password: batch-jobs-pw
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -33,19 +33,27 @@ prometheus:
   enabled: true
 
 kafka:
+  # Note: disable for production usage
   enabled: true
   fullnameOverride: "kafka"
   port: "9092"
 
 redis:
+  # Note: disable for production usage
   enabled: true
   fullnameOverride: "redis-strm"
   global:
     redis:
 
 postgresql:
+  # Note: disable for production usage
   enabled: true
   fullnameOverride: "postgres"
+  auth:
+    # The postgres user's password doesn't get set correctly due to an issue with the bitnami chart, so we create a different user here
+    # See https://github.com/bitnami/charts/issues/14469
+    username: batch-jobs-user
+    password: batch-jobs-pw
 
 services:
   # For routing traffic from outside the cluster
@@ -112,8 +120,12 @@ components:
       postgres:
         host:
         port:
-        user:
-        password: ""
+        user: batch-jobs-user
+        # Alternatively, provide an existing secret containing the postgres password below
+        password:
+        # If no secret exists, a password can be specified above, and a secret will be created for it (leave these empty then)
+        passwordSecretName: postgres
+        passwordSecretKeyName: password
         database:
 
 


### PR DESCRIPTION
This PR fixes the rbac permissions for the batch-exporters-agent and streams-agent, used for getting pod logs, and improves the default postgres password setup, which could result in mismatches between the postgres pod and its persistent volume, if the latter wasn't removed. The custom db user with static password makes development more convenient.